### PR TITLE
Gives credit to original author of project that was forked

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "name": "Christoph Gockel",
     "email": "cgockel@8thlight.com"
   },
+  "contributors": [{
+    "name": "Ellipsis Team",
+  }],
   "repository": "https://github.com/christophgockel/atom-sftp-sync",
   "bugs": {
     "url": "https://github.com/christophgockel/atom-sftp-sync/issues"


### PR DESCRIPTION
This should have been done from the beginning. My apologies to @amoussard and the original team of `sftp-deployment`.