### PR TITLE
Silences messages when config file could not be found

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Plugin keeps quiet when a project doesn't contain a config file.
+
+
 ## [2.1.0] - 2017-12-15
 
 ### Added

--- a/lib/configs/ConfigFactory.js
+++ b/lib/configs/ConfigFactory.js
@@ -45,23 +45,14 @@ export default class ConfigFactory {
     return new Promise((resolve, reject) => {
       fs.readFile(configPath, "utf8", (err, content) => {
         if (err) {
-          reject(err);
+          console.debug("No configuration file for Atom-SFTP-sync found.");
         } else {
           resolve(content);
         }
       });
     })
       .then((content) => this.parseConfigFile(content))
-      .then((configData) => this.createConfig(configData))
-      .catch((e) => {
-        if (e.code === "ENOENT") {
-          throw new NoConfigurationFileFoundException();
-        } else if (e.code === "EACCES") {
-          throw new ConfigurationFileNotReadableException();
-        } else {
-          throw e;
-        }
-      });
+      .then((configData) => this.createConfig(configData));
   }
 
   createSftpConfig() {
@@ -80,4 +71,3 @@ export default class ConfigFactory {
     return config;
   }
 }
-


### PR DESCRIPTION
It's adding a debug log entry instead. This should help keeping the plugin a bit more quiet and less invasive. It is expected that not every local project requires SFTP uploads.

Addresses #4.